### PR TITLE
Fix NPC dialog fetching to exclude other types

### DIFF
--- a/frontend/app/pages/stories/[id].vue
+++ b/frontend/app/pages/stories/[id].vue
@@ -73,9 +73,16 @@ onMounted(async () => {
 
         // Traitement des dialogues
         const rawDialogs = npc?.dialogs?.data || npc?.dialogs || [];
+
+        // Filtrer uniquement les dialogues de type "journal_entries"
+        const journalDialogs = rawDialogs.filter((dObj) => {
+            const d = dObj.attributes || dObj;
+            return d.text_type === 'journal_entries';
+        });
+
         const entries = [];
 
-        rawDialogs.forEach((dObj) => {
+        journalDialogs.forEach((dObj) => {
             const d = dObj.attributes || dObj;
             const texts = d.dialogues || [];
 


### PR DESCRIPTION
…al_entries

Ajout d'un filtre dans la page stories/[id].vue pour ne récupérer que les dialogues de type "journal_entries" lors de l'affichage du journal d'un NPC. Cela évite d'afficher les autres types de dialogues (quest_description, expedition_appear, etc.).