### PR TITLE
Filter story dialogs to only include journal entries

### DIFF
--- a/frontend/app/pages/stories/[id].vue
+++ b/frontend/app/pages/stories/[id].vue
@@ -73,9 +73,16 @@ onMounted(async () => {
 
         // Traitement des dialogues
         const rawDialogs = npc?.dialogs?.data || npc?.dialogs || [];
+
+        // Filtrer uniquement les dialogues de type "journal_entries"
+        const journalDialogs = rawDialogs.filter((dObj) => {
+            const d = dObj.attributes || dObj;
+            return d.text_type === 'journal_entries';
+        });
+
         const entries = [];
 
-        rawDialogs.forEach((dObj) => {
+        journalDialogs.forEach((dObj) => {
             const d = dObj.attributes || dObj;
             const texts = d.dialogues || [];
 


### PR DESCRIPTION
## Summary
Modified the story page to filter NPC dialogs and only process entries of type "journal_entries", preventing non-journal dialog types from being included in the story entries list.

## Changes
- Added filtering logic to the dialog processing pipeline that checks the `text_type` attribute
- Only dialogs with `text_type === 'journal_entries'` are now processed into story entries
- The filter handles both normalized (with `attributes` property) and denormalized dialog objects

## Implementation Details
The filter is applied before the forEach loop that processes dialogs into entries. This ensures that only relevant journal entry dialogs are included in the final entries array, improving data accuracy and preventing unintended dialog types from appearing in the story.

https://claude.ai/code/session_01VR5AdbtBoQ8Mu2v5SF5hrZ